### PR TITLE
Verify revision arguments for the `log` command

### DIFF
--- a/src/core/commands/log.rs
+++ b/src/core/commands/log.rs
@@ -61,9 +61,9 @@ pub fn log(args: &Namespace) -> Result<String, String> {
     let max_commits = option_to_int!(args.get("max"), usize::MAX, "max");
     let oneline = args.get("oneline").is_some();
     let show_author = args.get("no-author").is_none();
-    let treeish = &args["treeish"];
+    let revision = &args["revision"];
 
-    _log(&repo, treeish, max_commits, oneline, show_author)
+    _log(&repo, revision, max_commits, oneline, show_author)
 }
 
 fn format_commit(
@@ -143,12 +143,12 @@ fn extract_name(author_string: &str) -> Option<&str> {
 
 fn _log(
     repo: &GitRepository,
-    treeish: &str,
+    revision: &str,
     max_commits: usize,
     oneline: bool,
     show_author: bool,
 ) -> Result<String, String> {
-    let mut current = find_object(repo, treeish, None, false)?;
+    let mut current = find_object(repo, revision, None, false)?;
     let mut output = String::new();
     let mut count = 0;
 
@@ -204,7 +204,7 @@ pub fn make_parser() -> ArgumentParser {
         .optional()
         .add_help("Don't show author information");
     parser
-        .add_argument("treeish", ArgumentType::String)
+        .add_argument("revision", ArgumentType::String)
         .required()
         .default("HEAD")
         .add_help("Start from this commit or tag");

--- a/tests/core/test_log.rs
+++ b/tests/core/test_log.rs
@@ -206,7 +206,7 @@ Second commit"
     fn test_log_specific_commit() {
         setup();
 
-        let args: [&[&str]; 1] = [&["--treeish", &"a".repeat(40)]];
+        let args: [&[&str]; 1] = [&["--revision", &"a".repeat(40)]];
 
         let res = switch_dir!({
             let namespace = make_namespaces(&args).next().unwrap();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for unsupported Git object types in the log function.
	- Standardized terminology for commit references by renaming `treeish` to `revision`.

- **Bug Fixes**
	- Improved robustness of the log function to prevent errors when displaying history for unsupported object types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->