### PR TITLE
Normalize Windows paths to POSIX format for git tree comparisons (fixes #71)

### DIFF
--- a/src/core/commands/mod.rs
+++ b/src/core/commands/mod.rs
@@ -12,6 +12,8 @@ use std::path::Path;
 use crate::core::objects::worktree;
 use crate::core::GitRepository;
 
+use crate::utils::path;
+
 #[macro_export]
 macro_rules! parse_arg_as_int {
     ($value:expr, $err_msg:literal) => {
@@ -70,6 +72,10 @@ pub fn resolve_cla_files(
         // Create a path by joining the current working directory with the file path
         let file_path = cwd.join(file);
 
+        if !file_path.exists() {
+            return Err(format!("path '{file}' is not in the working tree"));
+        }
+
         // Canonicalize the path to get the absolute path
         let abs_path = file_path
             .canonicalize()
@@ -89,7 +95,7 @@ pub fn resolve_cla_files(
                 })?;
 
             // Convert the relative path to a string and store it
-            resolved_files.push(rel_path.to_string_lossy().to_string());
+            resolved_files.push(path::to_posix_path(rel_path)?);
         } else if abs_path.is_dir() {
             // Get all files under this directory
             let worktree_files =
@@ -103,7 +109,7 @@ pub fn resolve_cla_files(
                     format!("Could not get path relative to repo root for {file}")
                 })?;
 
-                resolved_files.push(rel_path.to_string_lossy().to_string());
+                resolved_files.push(path::to_posix_path(rel_path)?);
             }
         } else {
             return Err(format!("{file} is neither a file nor a directory"));

--- a/src/core/objects/worktree.rs
+++ b/src/core/objects/worktree.rs
@@ -87,7 +87,7 @@ fn collect_worktree_files(
                 .strip_prefix(base)
                 .map_err(|_| "Failed to get relative path".to_owned())?;
             paths.push(FileSource::Worktree {
-                path: relative.as_os_str().to_string_lossy().into_owned(),
+                path: crate::utils::path::to_posix_path(relative)?,
             });
         } else if path.is_dir() {
             collect_worktree_files(base, &path, paths)?;

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -662,7 +662,7 @@ mod tests {
             }
         } else {
             let test_cases = vec![
-                ("/", ""),
+                ("/", "/"),
                 ("/path", "path"),
                 ("/path/to/file", "path/to/file"),
             ];
@@ -708,7 +708,7 @@ mod tests {
             // Hidden files
             (".hidden", ".hidden"),
             // Absolute paths
-            ("/usr/local/bin", "usr/local/bin"),
+            ("/usr/local/bin", "/usr/local/bin"),
             // Current directory references
             ("./path", "./path"),
             // Parent directory references

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -663,8 +663,8 @@ mod tests {
         } else {
             let test_cases = vec![
                 ("/", "/"),
-                ("/path", "path"),
-                ("/path/to/file", "path/to/file"),
+                ("/path", "/path"),
+                ("/path/to/file", "/path/to/file"),
             ];
 
             for (input, expected) in test_cases {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new function for converting filesystem paths to POSIX-compliant strings, enhancing path handling.

- **Improvements**
  - Enhanced error handling for file path resolution, providing clearer error messages and ensuring paths are correctly formatted.
  - Updated methods for retrieving worktree files to ensure consistent path formatting.

- **Documentation**
  - Added examples for the new path conversion function, illustrating usage across different operating systems.

- **Tests**
  - Introduced new tests for the `to_posix_path` function, covering various scenarios for path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->